### PR TITLE
Get tabs safely on TST 3.0.12 and later

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -137,7 +137,7 @@ async function handleScroll(aMessage) {
         return handleWindowScroll(aMessage)
     }
 
-    let tabs = await browser.tabs.query({ windowId: aMessage.windowId });
+    let tabs = await browser.tabs.query({ windowId: aMessage.windowId || aMessage.window });
     let activeTabIndex = tabs.findIndex(tab => tab.active);
     let direction = aMessage.deltaY > 0 ? 1 : -1;
     direction = scrollingInverted ? -direction : direction;

--- a/js/background.js
+++ b/js/background.js
@@ -137,15 +137,16 @@ async function handleScroll(aMessage) {
         return handleWindowScroll(aMessage)
     }
 
-    let activeTabIndex = aMessage.tabs.findIndex(tab => tab.active);
+    let tabs = await browser.tabs.query({ windowId: aMessage.windowId });
+    let activeTabIndex = tabs.findIndex(tab => tab.active);
     let direction = aMessage.deltaY > 0 ? 1 : -1;
     direction = scrollingInverted ? -direction : direction;
     let id;
 
     if (skipCollapsed) {
-        id = findNonCollapsedTab(aMessage.tabs, direction, activeTabIndex);
+        id = findNonCollapsedTab(tabs, direction, activeTabIndex);
     } else {
-        id = findAnyNextTab(activeTabIndex, direction, aMessage.tabs);
+        id = findAnyNextTab(activeTabIndex, direction, tabs);
     }
     await browser.tabs.update(id, {active: true});
     return true;


### PR DESCRIPTION
On TST 3.0.12 and later, `tab` and `tabs` delivered via its API won't have `tabs.Tab` compatible properties by default, due to security reasons. These changes should make this addon compatible to TST 3.0.12 and later.

For more details, please see the updated API document:
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#information-in-private-windows
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#extra-permissions
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#data-format
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#when-permissions-for-your-addon-are-changed
